### PR TITLE
Refactor theme store and UI color management

### DIFF
--- a/.cursor/rules/frontend-patterns.mdc
+++ b/.cursor/rules/frontend-patterns.mdc
@@ -10,7 +10,7 @@ alwaysApply: false
 
 - **토큰**: `front/src/styles/design-system.ts` — `OBJ_CURSOR_NEUTRAL`, `fnBuildDesignSystem`, Ant `ConfigProvider` (`App.tsx`)
 - **셸**: `MainLayout.tsx` + `objShell` (사이드바·헤더 동일 톤, 44px 헤더, 흰 `dqpm-layout-content-panel`, `data-dqpm-theme` 스크롤바)
-- **primary 기본**: `#5B6ADF` (`useThemeStore` «Cursor»). 페이지 색은 **`theme.useToken()` / `useDesignSystem().objColor`** — hex 하드코드 지양
+- **primary 기본**: `#434343` (`STR_PRIMARY_CURSOR_NEUTRAL`, UI «Cursor»). 브랜드 오렌지 `#f54e00`는 «브랜드 오렌지» 프리셋. 페이지 색은 **`theme.useToken()`** — hex 하드코드 지양
 - **검토표**: `docs/CURSOR-UI-AUDIT.md` (컴포넌트별 ✅/🟡/🔴, 3단계 우선순위)
 - **CRUD 목록 골격**: `CrudPageShell` — 헤더 DbConnection, `Card`+테이블 User (`nodeToolbar`+`CrudListToolbar`)
 - **목록 툴바**: `CrudListToolbar` — `nodeLeft` **Segmented**(사용자·나의 대시보드), `nodeRight`(Select·버튼). 활동은 `Form` 필터(별 패턴)

--- a/.cursor/skills/db-event-manager/SKILL.md
+++ b/.cursor/skills/db-event-manager/SKILL.md
@@ -70,7 +70,7 @@ description: Database Query Process Manager(DQPM) 프로젝트 전체 컨텍스�
 - **쿼리 템플릿 단일·다중 세트 로직**: `docs/QUERY-TEMPLATE-QUERY-LOGIC.md`
 - **인앱 알림 목록(설계·검토)**: `docs/NOTIFICATIONS-DESIGN.md`
 - **레이아웃 타입·기본값**: `front/src/types/dashboardLayout.ts`, `front/src/constants/dashboardLayoutDefault.ts`
-- **Cursor 스타일 UI**: `front/src/styles/design-system.ts` (`OBJ_CURSOR_NEUTRAL`, `objShell`), `MainLayout.tsx`, `useThemeStore` (primary «Cursor» `#5B6ADF`) · 컴포넌트 검토 `docs/CURSOR-UI-AUDIT.md`
+- **Cursor 스타일 UI**: `design-system.ts` (`OBJ_CURSOR_NEUTRAL`, `objShell`), `MainLayout.tsx` · primary 기본 `STR_PRIMARY_CURSOR_NEUTRAL` `#434343` («Cursor»), 브랜드 `#f54e00` («브랜드 오렌지») · `docs/CURSOR-UI-AUDIT.md`
 
 ```
 backend/src/

--- a/docs/CURSOR-UI-AUDIT.md
+++ b/docs/CURSOR-UI-AUDIT.md
@@ -11,7 +11,7 @@
 | Container | `#FFFFFF` | `#252526` |
 | Sider | `#F7F7F7` | `#252526` |
 | Border | `#E5E5E5` / `#E8E8E8` | `rgba(255,255,255,0.08–0.10)` |
-| Primary 기본 | `#5B6ADF` (UI 설정 «Cursor») | 동일 |
+| Primary 기본 | `#434343` (Cursor 앱 중성, UI «Cursor») | `#f54e00`는 «브랜드 오렌지» 선택 |
 
 ## 컴포넌트·페이지 매트릭스
 
@@ -83,3 +83,7 @@
 cd front; npm run dev
 # UI 설정 → Cursor primary / 다크 모드 / 기본값 초기화
 ```
+
+## 일지
+
+- **2026-05-29** 상세 목록·보류 항목: [`WORKLOG-2026-05-29.md`](./WORKLOG-2026-05-29.md)

--- a/docs/WORKLOG-2026-05-29.md
+++ b/docs/WORKLOG-2026-05-29.md
@@ -1,0 +1,69 @@
+# 작업 일지 — 2026-05-29 (Cursor UI · 레이아웃)
+
+> 브랜치: `fix/code-improvements-round1` · **미커밋** (로컬 변경 14파일)
+
+## 완료 (커밋 대기)
+
+| # | 영역 | 내용 | 주요 파일 |
+|---|------|------|-----------|
+| 1 | **Cursor 셸** | 회색 레이아웃·흰 콘텐츠 패널·사이드/헤더 토큰 | `design-system.ts`, `MainLayout.tsx`, `index.css` |
+| 2 | **Primary 색** | 기본 `#434343`(앱 중성 «Cursor»), `#f54e00`는 «브랜드 오렌지» 프리셋 | `useThemeStore.ts`, `DesignSystemContext.tsx` |
+| 3 | **테마 모드** | `system` 제거 → `light` \| `dark`만, 기본 `light` | `useThemeStore.ts`, `SettingsDrawer.tsx` |
+| 4 | **다크 전환 버그** | `fnGetIsDark` 구독 → `strMode === 'dark'` 직접 구독 | `App.tsx`, `LoginPage.tsx`, `AuthCardLayout.tsx`, `QueryPage.tsx` |
+| 5 | **사이드바 리사이즈** | 5px 핸들, 160↓ 접힘, 접힌 뒤 드래그 펼침, 더블클릭 200px | `MainLayout.tsx`, `useThemeStore.ts` |
+| 6 | **펼침 드래그** | 80→160 점프 방지 (`fnSetSiderWidth(_, false)` + mouseup 스냅) | 동일 |
+| 7 | **헤더** | `MenuFold`/`MenuUnfold` 제거 (드래그만) | `MainLayout.tsx` |
+| 8 | **테이블 overflow** | `scroll.x`·`tableLayout=fixed`·패널 `min-width:0` | `AppTable.tsx`, `index.css` |
+| 9 | **CRUD 골격** | `CrudPageShell` / `CrudListToolbar` (이미 트래킹됨) | `docs/CURSOR-UI-AUDIT.md` 참고 |
+| 10 | **문서·규칙** | 감사 문서·SKILL·frontend-patterns 소폭 갱신 | `docs/CURSOR-UI-AUDIT.md`, `.cursor/*` |
+
+## 대화 중 논의 · 미반영(보류)
+
+| 항목 | 상태 | 메모 |
+|------|------|------|
+| 헤더 «관리자 관리자» 중복 | ✅ | `strDisplayName` = 역할 라벨일 때 Tag 숨김 + 툴팁 |
+| 사용자·톱니 → 사이드바 하단 | ⏸ 보류 | Cursor 레퍼런스 검토만 완료 |
+| 설정 전용 `/settings` 페이지 | ⏸ 보류 | 현재 `SettingsDrawer` 유지 |
+| 3단계 hex → token (`MyDashboard`/`Dashboard`) | ⏸ 보류 | `CURSOR-UI-AUDIT.md` 3단계 |
+| `MyDashboard` 액션열 `fixed: 'right'` | ⏸ 선택 | |
+
+## 알려진 이슈
+
+| 이슈 | 심각도 | 조치 |
+|------|--------|------|
+| ~~`npm run build` — `MyDashboardPage.tsx:2137`~~ | ✅ | `fnCopy(str?: string)` 로 수정 |
+| E2E·시드·`backend/data/*.json` 등 | 🟡 | 오늘 UI 범위 밖 — 별도 커밋/`.gitignore` 검토 |
+| `fnGetIsDark` 스토어 잔존 | 🟢 | 미사용 — 제거 가능 |
+
+## 변경 파일 (git diff 기준)
+
+```
+.cursor/rules/frontend-patterns.mdc
+.cursor/skills/db-event-manager/SKILL.md
+docs/CURSOR-UI-AUDIT.md
+front/src/App.tsx
+front/src/components/AppTable.tsx
+front/src/components/AuthCardLayout.tsx
+front/src/components/MainLayout.tsx
+front/src/components/SettingsDrawer.tsx
+front/src/index.css
+front/src/pages/DashboardPage.tsx
+front/src/pages/LoginPage.tsx
+front/src/pages/QueryPage.tsx
+front/src/stores/useThemeStore.ts
+front/src/styles/DesignSystemContext.tsx
+```
+
+## 검증 체크리스트
+
+- [x] `cd front; npm run build` 성공
+- [ ] UI 설정: 라이트/다크 전환 즉시 반영
+- [ ] 사이드바: 왼쪽 당김 → 80px / 오른쪽 당김 → 80px부터 부드럽게 확대
+- [ ] 긴 테이블 페이지 가로 스크롤 (User, DbConnection 등)
+- [x] admin 로그인 시 헤더 이름·역할 중복 없음 (코드 기준)
+
+## 다음 작업 우선순위 (제안)
+
+1. ~~빌드 오류 + 헤더 역할 Tag 중복~~ (완료)
+2. UI 14파일 + `WORKLOG` 커밋 (`feat(ui): Cursor shell, theme, sider resize, table scroll`)
+3. (선택) 사이드바 하단 프로필 / 3단계 hex 정리

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -147,24 +147,10 @@ const App = () => {
   const bIsAuthenticated = useAuthStore((state) => state.bIsAuthenticated);
 
   // 테마 스토어
-  const fnGetIsDark = useThemeStore((state) => state.fnGetIsDark);
+  const strMode = useThemeStore((state) => state.strMode);
   const nFontSize = useThemeStore((state) => state.nFontSize);
   const bCompact = useThemeStore((state) => state.bCompact);
   const strPrimaryColor = useThemeStore((state) => state.strPrimaryColor);
-  const strMode = useThemeStore((state) => state.strMode);
-
-  // system 모드일 때 OS 변경 감지하여 리렌더 유도
-  useEffect(() => {
-    if (strMode !== 'system') return;
-    const objMq = window.matchMedia('(prefers-color-scheme: dark)');
-    const fnHandler = () => {
-      // 리렌더 트리거: 스토어 액션 없이 강제 재평가를 위해 임시 상태 변경
-      useThemeStore.setState((s) => ({ ...s }));
-    };
-    objMq.addEventListener('change', fnHandler);
-    return () => objMq.removeEventListener('change', fnHandler);
-  }, [strMode]);
-
   // 앱 시작 시 토큰 검증 (자동 로그인)
   useEffect(() => {
     fnVerifyToken();
@@ -183,7 +169,7 @@ const App = () => {
 
   // 프로덕트/이벤트/DB목록은 각 페이지에서 로드(전역 prefetch 시 활동 로그·이중 GET 증가)
 
-  const bIsDark = fnGetIsDark();
+  const bIsDark = strMode === 'dark';
 
   // CSS 변수·스크롤바 등 전역 테마 동기화
   useEffect(() => {

--- a/front/src/components/AppTable.tsx
+++ b/front/src/components/AppTable.tsx
@@ -371,6 +371,29 @@ function fnGetColKey<T>(col: TableColumnType<T>, nIdx: number): string {
   return String(col.key ?? (col.dataIndex as string) ?? `__col_${nIdx}`);
 }
 
+/** width 미지정 컬럼 추정 너비 — 좁은 뷰포트에서 가로 스크롤 합산용 */
+const N_DEFAULT_COL_WIDTH = 140;
+const N_MIN_TABLE_SCROLL_X = 480;
+
+function fnComputeScrollX<T>(
+  arrCols: TableColumnType<T>[] | undefined,
+  objWidths: Record<string, number>,
+  expandable?: TableProps<T>['expandable'],
+): number {
+  if (!arrCols?.length) return N_MIN_TABLE_SCROLL_X;
+  let nSum = 0;
+  if (expandable) {
+    const nExpandW = expandable.columnWidth;
+    nSum += typeof nExpandW === 'number' ? nExpandW : 48;
+  }
+  arrCols.forEach((col, nIdx) => {
+    const strKey = fnGetColKey(col, nIdx);
+    const w = objWidths[strKey] ?? col.width;
+    nSum += typeof w === 'number' ? w : N_DEFAULT_COL_WIDTH;
+  });
+  return Math.max(nSum, N_MIN_TABLE_SCROLL_X);
+}
+
 // ─── AppTable Props ──────────────────────────────────────────
 interface IAppTableProps<T> extends TableProps<T> {
   strEmptyText?: string;
@@ -391,6 +414,8 @@ function AppTable<T extends object>({
   columns,
   bDraggableColumns = true,
   strTableId,
+  scroll: scrollProp,
+  expandable,
   ...restProps
 }: IAppTableProps<T>) {
   const { token } = antdTheme.useToken();
@@ -488,6 +513,18 @@ function AppTable<T extends object>({
           .filter(Boolean) as TableColumnType<T>[]
       : (columns as TableColumnType<T>[] | undefined);
 
+  const arrColsForLayout = arrSortedColumns ?? (columns as TableColumnType<T>[] | undefined);
+
+  const nScrollX = useMemo(
+    () => fnComputeScrollX(arrColsForLayout, objWidths, expandable),
+    [arrColsForLayout, objWidths, expandable],
+  );
+
+  const objScroll = useMemo((): TableProps<T>['scroll'] => {
+    const mixX = scrollProp?.x ?? nScrollX;
+    return { ...scrollProp, x: mixX };
+  }, [scrollProp, nScrollX]);
+
   const objPagination =
     pagination === false
       ? false
@@ -508,9 +545,11 @@ function AppTable<T extends object>({
     <Table<T>
       size={size}
       rowKey={rowKey}
-      columns={arrSortedColumns}
+      columns={arrColsForLayout}
       pagination={objPagination}
       locale={{ emptyText: strEmptyText, ...locale }}
+      scroll={objScroll}
+      tableLayout={objScroll?.x ? 'fixed' : undefined}
       style={{
         transition: 'background-color 0.2s ease',
         borderRadius: token.borderRadius,
@@ -525,13 +564,14 @@ function AppTable<T extends object>({
             }
           : undefined
       }
+      expandable={expandable}
       {...restProps}
     />
   );
 
-  if (!bDraggableColumns) return objTable;
-
-  const tableContent = (
+  const nodeTableInner = !bDraggableColumns ? (
+    objTable
+  ) : (
     <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={fnOnDragEnd}>
       <SortableContext items={arrOrder} strategy={horizontalListSortingStrategy}>
         {objTable}
@@ -539,11 +579,13 @@ function AppTable<T extends object>({
     </DndContext>
   );
 
-  return (
+  const nodeTable = (
     <ResizeContext.Provider value={ctxResizeValue!}>
-      {tableContent}
+      {nodeTableInner}
     </ResizeContext.Provider>
   );
+
+  return <div className="dqpm-app-table-root">{nodeTable}</div>;
 }
 
 export default AppTable;

--- a/front/src/components/AuthCardLayout.tsx
+++ b/front/src/components/AuthCardLayout.tsx
@@ -25,9 +25,8 @@ const AuthCardLayout = ({
   nWidth = 420,
 }: IAuthCardLayoutProps) => {
   const { token } = theme.useToken();
-  const fnGetIsDark = useThemeStore((s) => s.fnGetIsDark);
   const strPrimaryColor = useThemeStore((s) => s.strPrimaryColor);
-  const bIsDark = fnGetIsDark();
+  const bIsDark = useThemeStore((s) => s.strMode === 'dark');
   const strPageBackground = `radial-gradient(ellipse 110% 70% at 50% -18%, ${strPrimaryColor}40 0%, transparent 52%), ${token.colorBgLayout}`;
 
   return (

--- a/front/src/components/MainLayout.tsx
+++ b/front/src/components/MainLayout.tsx
@@ -1,12 +1,10 @@
 import { useState, useMemo, useRef, useCallback, useEffect } from 'react';
-import { Layout, Menu, Typography, Button, Avatar, Dropdown, Space, Tag, Badge, theme as antdTheme } from 'antd';
+import { Layout, Menu, Typography, Button, Avatar, Dropdown, Space, Tag, Badge, Tooltip, theme as antdTheme } from 'antd';
 import {
   DashboardOutlined,
   AppstoreOutlined,
   CalendarOutlined,
   CodeOutlined,
-  MenuFoldOutlined,
-  MenuUnfoldOutlined,
   LogoutOutlined,
   UserOutlined,
   DatabaseOutlined,
@@ -20,7 +18,13 @@ import {
 import { Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '../stores/useAuthStore';
 import { useEventStream } from '../hooks/useEventStream';
-import { useThemeStore, N_SIDER_MIN } from '../stores/useThemeStore';
+import {
+  useThemeStore,
+  N_SIDER_MIN,
+  N_SIDER_DEFAULT,
+  N_SIDER_COLLAPSED_WIDTH,
+  fnSiderMax,
+} from '../stores/useThemeStore';
 import { useDesignSystem } from '../styles/DesignSystemContext';
 import SettingsDrawer from './SettingsDrawer';
 import NotificationBellDropdown from './NotificationBellDropdown';
@@ -93,21 +97,37 @@ const MainLayout = () => {
   const nDragStartX = useRef(0);
   const nDragStartWidth = useRef(nSiderWidth);
   const bCollapsedRef = useRef(bCollapsed);
+  /** 접힌 상태에서 드래그로 펼치는 중 — nRaw<최소 시 즉시 재접힘 방지 */
+  const bExpandDragRef = useRef(false);
   bCollapsedRef.current = bCollapsed;
 
   const fnOnDragStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
     bDragging.current = true;
+    bExpandDragRef.current = false;
     setBIsResizingSider(true);
     nDragStartX.current = e.clientX;
-    nDragStartWidth.current = nSiderWidth;
+    nDragStartWidth.current = bCollapsedRef.current ? N_SIDER_COLLAPSED_WIDTH : nSiderWidth;
     document.body.style.cursor = 'col-resize';
     document.body.style.userSelect = 'none';
   }, [nSiderWidth]);
 
+  const fnOnResizeHandleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (bCollapsedRef.current) {
+        setBCollapsed(false);
+      }
+      fnSetSiderWidth(N_SIDER_DEFAULT);
+    },
+    [fnSetSiderWidth],
+  );
+
   useEffect(() => {
     const fnEndDragChrome = () => {
       bDragging.current = false;
+      bExpandDragRef.current = false;
       setBIsResizingSider(false);
       document.body.style.cursor = '';
       document.body.style.userSelect = '';
@@ -115,24 +135,54 @@ const MainLayout = () => {
 
     const fnOnMouseMove = (e: MouseEvent) => {
       if (!bDragging.current) return;
-      if (bCollapsedRef.current) return;
 
       const nDelta = e.clientX - nDragStartX.current;
-      const nRaw = nDragStartWidth.current + nDelta;
 
-      // 최소 폭보다 더 줄이려 하면 접기 버튼과 동일하게 아이콘만 표시
-      if (nRaw < N_SIDER_MIN) {
+      // 접힌(아이콘) 상태에서 오른쪽으로 당기면 펼침 — 80px부터 커서를 따라감(160으로 점프하지 않음)
+      if (bCollapsedRef.current) {
+        if (nDelta <= 2) return;
+        setBCollapsed(false);
+        bCollapsedRef.current = false;
+        bExpandDragRef.current = true;
+        nDragStartWidth.current = N_SIDER_COLLAPSED_WIDTH;
+        nDragStartX.current = e.clientX;
+      }
+
+      const nRaw = nDragStartWidth.current + (e.clientX - nDragStartX.current);
+
+      if (bExpandDragRef.current) {
+        const nNext = Math.min(fnSiderMax(), Math.max(N_SIDER_COLLAPSED_WIDTH, nRaw));
+        fnSetSiderWidth(nNext, false);
+        return;
+      }
+
+      const nClamped = Math.min(fnSiderMax(), Math.max(N_SIDER_COLLAPSED_WIDTH, nRaw));
+
+      // 최소 폭보다 더 줄이려 하면 아이콘만 표시
+      if (nClamped < N_SIDER_MIN) {
         setBCollapsed(true);
+        bCollapsedRef.current = true;
         fnEndDragChrome();
         return;
       }
 
-      fnSetSiderWidth(nRaw);
+      fnSetSiderWidth(nClamped, true);
     };
 
     const fnOnMouseUp = () => {
       if (!bDragging.current) return;
+      const bWasExpandDrag = bExpandDragRef.current;
       fnEndDragChrome();
+      if (!bWasExpandDrag) return;
+      const nW = useThemeStore.getState().nSiderWidth;
+      if (nW < N_SIDER_COLLAPSED_WIDTH + 28) {
+        setBCollapsed(true);
+        bCollapsedRef.current = true;
+        return;
+      }
+      if (nW < N_SIDER_MIN) {
+        fnSetSiderWidth(N_SIDER_MIN, true);
+      }
     };
 
     window.addEventListener('mousemove', fnOnMouseMove);
@@ -246,6 +296,17 @@ const MainLayout = () => {
   const strFirstRole = arrRoles[0] || '';
   const objRole = objRoleLabel[strFirstRole] || { strText: strFirstRole, strColor: '#999' };
 
+  const strHeaderDisplayName = user?.strDisplayName?.trim() ?? '';
+  const bShowRoleTag =
+    Boolean(objRole.strText.trim()) &&
+    objRole.strText.trim().toLowerCase() !== strHeaderDisplayName.toLowerCase();
+  const strUserHoverHint =
+    !bShowRoleTag && user?.strUserId && user.strUserId.toLowerCase() !== strHeaderDisplayName.toLowerCase()
+      ? `아이디: ${user.strUserId}${objRole.strText ? ` · 역할: ${objRole.strText}` : ''}`
+      : !bShowRoleTag && objRole.strText
+        ? `역할: ${objRole.strText}`
+        : undefined;
+
   // 사이드 폭에 맞춰 로고 글자 크기 조절(좁게 당기면 자동으로 줄어듦)
   const nLogoFontPx = bCollapsed
     ? ds.objSider.nLogoFontSize
@@ -265,6 +326,7 @@ const MainLayout = () => {
         trigger={null}
         collapsible
         collapsed={bCollapsed}
+        collapsedWidth={N_SIDER_COLLAPSED_WIDTH}
         width={nSiderWidth}
         style={{
           overflow: 'auto',
@@ -328,32 +390,34 @@ const MainLayout = () => {
           }}
         />
 
-        {/* 드래그 리사이즈 핸들 — collapsed 시 숨김 */}
-        {!bCollapsed && (
-          <div
-            onMouseDown={fnOnDragStart}
-            style={{
-              position: 'absolute',
-              top: 0,
-              right: 0,
-              width: 5,
-              height: '100%',
-              cursor: 'col-resize',
-              zIndex: 20,
-              // hover 시 primary 컬러로 하이라이트
-              background: 'transparent',
-              transition: 'background 0.15s',
-            }}
-            onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = ds.objSider.strResizeHandle; }}
-            onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = 'transparent'; }}
-          />
-        )}
+        {/* 드래그 리사이즈 — 당김: 아이콘 모드 / 펼침: 너비 조절 · 더블클릭: 기본 200px */}
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          title="드래그: 너비 조절(왼쪽으로 당기면 아이콘만) · 더블클릭: 기본 너비"
+          onMouseDown={fnOnDragStart}
+          onDoubleClick={fnOnResizeHandleDoubleClick}
+          className="dqpm-sider-resize-handle"
+          style={{
+            position: 'absolute',
+            top: 0,
+            right: 0,
+            width: 5,
+            height: '100%',
+            cursor: 'col-resize',
+            zIndex: 20,
+            background: 'transparent',
+            transition: 'background 0.15s',
+          }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLDivElement).style.background = ds.objSider.strResizeHandle; }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLDivElement).style.background = 'transparent'; }}
+        />
       </Sider>
 
       {/* 메인 영역 — 드래그 중에는 transition 제거로 버벅임 방지 */}
       <Layout
         style={{
-          marginLeft: bCollapsed ? 80 : nSiderWidth,
+          marginLeft: bCollapsed ? N_SIDER_COLLAPSED_WIDTH : nSiderWidth,
           background: objShell.strContentBg,
           transition: bIsResizingSider
             ? 'none'
@@ -377,17 +441,8 @@ const MainLayout = () => {
             zIndex: 9,
           }}
         >
-          {/* 사이드바 접기/펼치기 버튼 */}
-          <Button
-            type="text"
-            className="dqpm-header-icon-btn"
-            icon={bCollapsed ? <MenuUnfoldOutlined /> : <MenuFoldOutlined />}
-            onClick={() => setBCollapsed(!bCollapsed)}
-            style={{ fontSize: 16, color: token.colorTextSecondary }}
-          />
-
           {/* 실시간 연결 상태 + 사용자 정보 + 설정 버튼 */}
-          <Space>
+          <Space style={{ marginLeft: 'auto' }}>
             <Badge
               status={bConnected ? 'success' : 'default'}
               title={bConnected ? '실시간 연결됨' : '연결 중...'}
@@ -401,14 +456,16 @@ const MainLayout = () => {
             </Badge>
             <NotificationBellDropdown />
             <Dropdown menu={{ items: arrUserMenuItems }} placement="bottomRight">
-              <Space style={{ cursor: 'pointer' }}>
-                <Avatar
-                  icon={<UserOutlined />}
-                  style={{ background: objRole.strColor }}
-                />
-                <Text strong>{user?.strDisplayName}</Text>
-                <Tag color={objRole.strColor}>{objRole.strText}</Tag>
-              </Space>
+              <Tooltip title={strUserHoverHint}>
+                <Space style={{ cursor: 'pointer' }}>
+                  <Avatar
+                    icon={<UserOutlined />}
+                    style={{ background: objRole.strColor }}
+                  />
+                  <Text strong>{strHeaderDisplayName || user?.strUserId}</Text>
+                  {bShowRoleTag ? <Tag color={objRole.strColor}>{objRole.strText}</Tag> : null}
+                </Space>
+              </Tooltip>
             </Dropdown>
             {/* UI 설정 버튼 */}
             <Button

--- a/front/src/components/SettingsDrawer.tsx
+++ b/front/src/components/SettingsDrawer.tsx
@@ -3,7 +3,6 @@ import { Drawer, Segmented, Slider, Switch, Typography, Divider, Button, Tooltip
 import {
   SunOutlined,
   MoonOutlined,
-  DesktopOutlined,
   ReloadOutlined,
   CheckOutlined,
 } from '@ant-design/icons';
@@ -33,8 +32,6 @@ const SettingsDrawer = ({ bOpen, fnOnClose }: ISettingsDrawerProps) => {
   const nFontSize = useThemeStore((s) => s.nFontSize);
   const bCompact = useThemeStore((s) => s.bCompact);
   const strPrimaryColor = useThemeStore((s) => s.strPrimaryColor);
-  const fnGetIsDark = useThemeStore((s) => s.fnGetIsDark);
-
   const fnSetMode = useThemeStore((s) => s.fnSetMode);
   const fnSetFontSize = useThemeStore((s) => s.fnSetFontSize);
   const fnSetCompact = useThemeStore((s) => s.fnSetCompact);
@@ -43,7 +40,7 @@ const SettingsDrawer = ({ bOpen, fnOnClose }: ISettingsDrawerProps) => {
   const fnSetFunMode = useThemeStore((s) => s.fnSetFunMode);
   const fnReset = useThemeStore((s) => s.fnReset);
 
-  const bIsDark = fnGetIsDark();
+  const bIsDark = strMode === 'dark';
   const bWebPushSupported = fnIsWebPushSupported();
   const strWebPushUnsupportedReason = fnGetWebPushUnsupportedReason();
   const [bWebPushEnabled, setBWebPushEnabled] = useState(() => fnIsWebPushEnabledPref());
@@ -119,9 +116,8 @@ const SettingsDrawer = ({ bOpen, fnOnClose }: ISettingsDrawerProps) => {
         value={strMode}
         onChange={fnSetMode}
         options={[
-          { value: 'light',  icon: <SunOutlined />,     label: '라이트' },
-          { value: 'dark',   icon: <MoonOutlined />,    label: '다크' },
-          { value: 'system', icon: <DesktopOutlined />, label: '시스템' },
+          { value: 'light', icon: <SunOutlined />, label: '라이트' },
+          { value: 'dark', icon: <MoonOutlined />, label: '다크' },
         ]}
       />
 

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -91,6 +91,25 @@ html[data-dqpm-theme='light'] {
 
 .dqpm-crud-page-card > .ant-card-body {
   padding: 16px;
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* flex 레이아웃 안에서 테이블이 패널 밖으로 밀리지 않게 */
+.dqpm-layout-content-panel {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* AppTable — 좁은 브라우저에서 카드 안 가로 스크롤 */
+.dqpm-app-table-root {
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+.dqpm-app-table-root .ant-table-wrapper {
+  max-width: 100%;
 }
 
 /* 목록 툴바 — Segmented (사용자·나의 대시보드) */

--- a/front/src/pages/DashboardPage.tsx
+++ b/front/src/pages/DashboardPage.tsx
@@ -40,6 +40,7 @@ import {
 import { useProductStore } from '../stores/useProductStore';
 import { useEventStore } from '../stores/useEventStore';
 import { useAuthStore } from '../stores/useAuthStore';
+import { useThemeStore } from '../stores/useThemeStore';
 import { fnScopedStorageGetItem, fnScopedStorageSetItem } from '../utils/userScopedStorage';
 import { fnApiGetInstances } from '../api/eventInstanceApi';
 import { useDbConnectionStore } from '../stores/useDbConnectionStore';
@@ -904,6 +905,7 @@ const DashboardPage = () => {
   const fnFetchProducts = useProductStore((s) => s.fnFetchProducts);
   const fnFetchEvents = useEventStore((s) => s.fnFetchEvents);
   const arrPermissions = useAuthStore((s) => s.user?.arrPermissions ?? []);
+  const strPrimaryColor = useThemeStore((s) => s.strPrimaryColor);
 
   const fnHas = (strPerm: TPermission) => arrPermissions.includes(strPerm);
 
@@ -2088,7 +2090,7 @@ const DashboardPage = () => {
               >
                 {strId === 'product' && (
                   <DashboardCardContent
-                    icon={fnDashboardCardIcon(AppstoreOutlined, '#667eea')}
+                    icon={fnDashboardCardIcon(AppstoreOutlined, strPrimaryColor)}
                     title="프로덕트"
                   >
                     <span style={OBJ_CARD_VALUE_STYLE}>{arrProducts.length}개</span>

--- a/front/src/pages/LoginPage.tsx
+++ b/front/src/pages/LoginPage.tsx
@@ -20,9 +20,8 @@ const LoginPage = () => {
   const fnLogin = useAuthStore((state) => state.fnLogin);
   const [messageApi, contextHolder] = message.useMessage();
   const { token } = theme.useToken();
-  const fnGetIsDark = useThemeStore((s) => s.fnGetIsDark);
   const strPrimaryColor = useThemeStore((s) => s.strPrimaryColor);
-  const bIsDark = fnGetIsDark();
+  const bIsDark = useThemeStore((s) => s.strMode === 'dark');
   // 테마별 페이지 배경 — 본문·카드는 token으로 대비 확보
   const strPageBackground = `radial-gradient(ellipse 110% 70% at 50% -18%, ${strPrimaryColor}40 0%, transparent 52%), ${token.colorBgLayout}`;
 

--- a/front/src/pages/MyDashboardPage.tsx
+++ b/front/src/pages/MyDashboardPage.tsx
@@ -1026,7 +1026,7 @@ const MyDashboardPage = () => {
   };
 
   // 클립보드 복사
-  const fnCopy = (str: string) => {
+  const fnCopy = (str: string | undefined) => {
     fnCopyTextToClipboard(str, messageApi);
   };
 

--- a/front/src/pages/QueryPage.tsx
+++ b/front/src/pages/QueryPage.tsx
@@ -31,6 +31,7 @@ import { useProductStore } from '../stores/useProductStore';
 import { useEventStore } from '../stores/useEventStore';
 import { useDbConnectionStore } from '../stores/useDbConnectionStore';
 import { useAuthStore } from '../stores/useAuthStore';
+import { useThemeStore, fnGenPalette } from '../stores/useThemeStore';
 import { fnApiCreateInstance } from '../api/eventInstanceApi';
 import { useAutoRefresh } from '../hooks/useAutoRefresh';
 import type { IEventTemplate, IService, TDeployScope } from '../types';
@@ -78,6 +79,12 @@ const QueryPage = () => {
   const fnFetchDbConnections = useDbConnectionStore((s) => s.fnFetchDbConnections);
   const arrDbConnections = useDbConnectionStore((s) => s.arrDbConnections);
   const user = useAuthStore((s) => s.user);
+  const strPrimaryColor = useThemeStore((s) => s.strPrimaryColor);
+  const bIsDark = useThemeStore((s) => s.strMode === 'dark');
+  const strSubmitGradient = useMemo(() => {
+    const arrP = fnGenPalette(strPrimaryColor, bIsDark);
+    return `linear-gradient(135deg, ${strPrimaryColor} 0%, ${arrP[7]} 100%)`;
+  }, [strPrimaryColor, bIsDark]);
 
   // 페이지 진입 시 한 effect에서 목록 로드(StrictMode 이중 effect 시에도 스토어 dedupe로 GET 완화)
   useEffect(() => {
@@ -745,7 +752,7 @@ const QueryPage = () => {
                   block
                   size="large"
                   style={{
-                    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+                    background: strSubmitGradient,
                     border: 'none',
                     height: 48,
                     fontWeight: 600,

--- a/front/src/stores/useThemeStore.ts
+++ b/front/src/stores/useThemeStore.ts
@@ -4,11 +4,19 @@ import { generate } from '@ant-design/colors';
 import { useAuthStore } from './useAuthStore';
 
 // 테마 모드 타입
-export type TThemeMode = 'light' | 'dark' | 'system';
+export type TThemeMode = 'light' | 'dark';
+
+/** Cursor 앱 UI 톤 — 중성 primary (Automations 등 회색·잉크 강조) */
+export const STR_PRIMARY_CURSOR_NEUTRAL = '#434343';
+
+/** Cursor 마케팅 브랜드 오렌지 (CTA·cursor.com) — 선택용 */
+export const STR_PRIMARY_CURSOR_BRAND = '#f54e00';
 
 // 포인트 컬러 팔레트 정의
 export const ARR_PRIMARY_COLORS = [
-  { strLabel: 'Cursor', strValue: '#5B6ADF' },
+  { strLabel: 'Cursor', strValue: STR_PRIMARY_CURSOR_NEUTRAL },
+  { strLabel: '브랜드 오렌지', strValue: STR_PRIMARY_CURSOR_BRAND },
+  { strLabel: '인디고', strValue: '#5B6ADF' },
   { strLabel: '퍼플 블루', strValue: '#667eea' },
   { strLabel: '블루', strValue: '#1677ff' },
   { strLabel: '사이언', strValue: '#13c2c2' },
@@ -25,8 +33,12 @@ export function fnGenPalette(strPrimary: string, bDark = false): string[] {
   return generate(strPrimary, bDark ? { theme: 'dark', backgroundColor: '#141414' } : undefined);
 }
 
-// 사이드바 너비 한계: 최소 160px, 최대 화면 너비의 1/3 (동적)
+// 사이드바 너비 — Ant Design collapsed 폭(80)과 맞춤
+export const N_SIDER_COLLAPSED_WIDTH = 80;
+/** 드래그·펼침 시 최소 너비(이하로 당기면 아이콘 모드) */
 export const N_SIDER_MIN = 160;
+/** 더블클릭·초기화 시 기본 너비 */
+export const N_SIDER_DEFAULT = 200;
 export function fnSiderMax(): number {
   return Math.floor(window.innerWidth / 3);
 }
@@ -34,10 +46,10 @@ export function fnSiderMax(): number {
 // 기본값
 const OBJ_DEFAULT = {
   strMode: 'light' as TThemeMode,
-  nSiderWidth: 200,
+  nSiderWidth: N_SIDER_DEFAULT,
   nFontSize: 14,
   bCompact: false,
-  strPrimaryColor: '#5B6ADF',
+  strPrimaryColor: STR_PRIMARY_CURSOR_NEUTRAL,
   bFunMode: false, // 재미 모드: 재요청 버튼을 롱프레스로 전환
 };
 
@@ -49,12 +61,12 @@ interface IThemeStore {
   strPrimaryColor: string;
   bFunMode: boolean;
 
-  // 시스템 다크모드 여부 (system 모드일 때 OS 설정 반영)
   fnGetIsDark: () => boolean;
 
   // 액션
   fnSetMode: (strMode: TThemeMode) => void;
-  fnSetSiderWidth: (nWidth: number) => void;
+  /** bClampMin=false: 드래그로 펼칠 때 80~160 사이도 따라감(릴리스 시 보정) */
+  fnSetSiderWidth: (nWidth: number, bClampMin?: boolean) => void;
   fnSetFontSize: (nSize: number) => void;
   fnSetCompact: (bCompact: boolean) => void;
   fnSetPrimaryColor: (strColor: string) => void;
@@ -91,17 +103,13 @@ export const useThemeStore = create<IThemeStore>()(
     (set, get) => ({
       ...OBJ_DEFAULT,
 
-      // OS 다크모드 감지 포함한 실제 다크 여부
-      fnGetIsDark: () => {
-        const { strMode } = get();
-        if (strMode === 'dark') return true;
-        if (strMode === 'light') return false;
-        // system: OS prefers-color-scheme 감지
-        return window.matchMedia('(prefers-color-scheme: dark)').matches;
-      },
+      fnGetIsDark: () => get().strMode === 'dark',
 
       fnSetMode: (strMode) => set({ strMode }),
-      fnSetSiderWidth: (nWidth) => set({ nSiderWidth: Math.min(fnSiderMax(), Math.max(N_SIDER_MIN, nWidth)) }),
+      fnSetSiderWidth: (nWidth, bClampMin = true) => {
+        const nLo = bClampMin ? N_SIDER_MIN : N_SIDER_COLLAPSED_WIDTH;
+        set({ nSiderWidth: Math.min(fnSiderMax(), Math.max(nLo, nWidth)) });
+      },
       fnSetFontSize: (nSize) => set({ nFontSize: Math.min(25, Math.max(12, nSize)) }),
       fnSetCompact: (bCompact) => set({ bCompact }),
       fnSetPrimaryColor: (strColor) => set({ strPrimaryColor: strColor }),
@@ -112,6 +120,15 @@ export const useThemeStore = create<IThemeStore>()(
       name: 'db-event-manager-theme',
       storage: createJSONStorage(() => themePersistStorage),
       skipHydration: true,
+      version: 1,
+      migrate: (persisted) => {
+        const obj = persisted as { strMode?: string };
+        if (obj.strMode === 'system') {
+          const bDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+          return { ...obj, strMode: bDark ? 'dark' : 'light' };
+        }
+        return persisted;
+      },
       partialize: (state) => ({
         strMode: state.strMode,
         nSiderWidth: state.nSiderWidth,

--- a/front/src/styles/DesignSystemContext.tsx
+++ b/front/src/styles/DesignSystemContext.tsx
@@ -1,9 +1,10 @@
 import { createContext, useContext } from 'react';
 import type { IDesignSystem } from './design-system';
 import { fnBuildDesignSystem } from './design-system';
+import { STR_PRIMARY_CURSOR_NEUTRAL } from '../stores/useThemeStore';
 
 // 기본값 — 실제로는 App에서 항상 주입되므로 fallback용
-const OBJ_DEFAULT_DS = fnBuildDesignSystem('#5B6ADF', false, 14);
+const OBJ_DEFAULT_DS = fnBuildDesignSystem(STR_PRIMARY_CURSOR_NEUTRAL, false, 14);
 
 export const DesignSystemContext = createContext<IDesignSystem>(OBJ_DEFAULT_DS);
 


### PR DESCRIPTION
- Removed 'system' mode from theme mode options, simplifying to 'light' and 'dark'.
- Introduced new primary colors for the Cursor app: neutral (#434343) and brand orange (#f54e00).
- Updated default values and functions in `useThemeStore` to reflect new color scheme.
- Adjusted components to utilize the new primary color and improved sidebar width handling.
- Enhanced CSS styles to prevent layout issues in flex containers and ensure proper responsiveness.