### PR TITLE
refactor(slackNotifier): Enhance public base URL handling for instanc…

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -56,7 +56,11 @@ JWT_EXPIRES_IN=24h
 # 프로덕트 GM 채널 — 해당 프로덕트 QA·LIVE 반영 완료 (기본: qa_deployed,live_deployed)
 # SLACK_NOTIFY_PRODUCT_STATUSES=qa_deployed,live_deployed
 # Slack 메시지 «나의 대시보드» 버튼용 공개 프론트 URL (미설정 시 버튼 생략)
-# DQPM_PUBLIC_BASE_URL=https://db.masangsoft.com
+# Slack·앱 링크용 공개 URL (EC2 shared/backend.env — QA/LIVE 각각 다르게)
+# DQPM_PUBLIC_BASE_URL=https://qa-db.masanggames.co.kr   # LIVE: https://db.masanggames.co.kr
+# 선택: 한 서버에서 QA·LIVE 알림 URL을 나누려면 (상태별 우선)
+# DQPM_PUBLIC_BASE_URL_QA=https://qa-db.masanggames.co.kr
+# DQPM_PUBLIC_BASE_URL_LIVE=https://db.masanggames.co.kr
 # Web Push(VAPID) — 미설정 시 구독 API는 503, 공개키 API는 bEnabled=false
 # npx web-push generate-vapid-keys 로 키 생성
 # VAPID_PUBLIC_KEY=

--- a/backend/src/__tests__/slackNotifier.test.ts
+++ b/backend/src/__tests__/slackNotifier.test.ts
@@ -63,6 +63,8 @@ describe('slackNotifier', () => {
     delete process.env.SLACK_NOTIFY_PRODUCT_STATUSES;
     delete process.env.SLACK_NOTIFY_DBA_TEMPLATE_STATUSES;
     delete process.env.DQPM_PUBLIC_BASE_URL;
+    delete process.env.DQPM_PUBLIC_BASE_URL_QA;
+    delete process.env.DQPM_PUBLIC_BASE_URL_LIVE;
   });
 
   afterAll(() => {
@@ -164,6 +166,45 @@ describe('slackNotifier', () => {
     expect(fnFetchMock.mock.calls[0][0]).toBe('https://hooks.slack.com/services/ad');
     const objBody = JSON.parse(String((fnFetchMock.mock.calls[0][1] as RequestInit).body));
     expect(objBody.blocks?.[0]?.text?.text).toBe('QA 반영 완료');
+  });
+
+  it('qa_deployed·live_deployed 는 상태별 공개 URL 을 사용한다', async () => {
+    process.env.SLACK_NOTIFICATIONS_ENABLED = '1';
+    process.env.SLACK_WEBHOOK_URL_FH = 'https://hooks.slack.com/services/fh';
+    process.env.DQPM_PUBLIC_BASE_URL = 'https://wrong.example.com';
+    process.env.DQPM_PUBLIC_BASE_URL_QA = 'https://qa-db.example.com';
+    process.env.DQPM_PUBLIC_BASE_URL_LIVE = 'https://db.example.com';
+    const { fnNotifySlackInstanceUpdate } = await import('../services/slackNotifier');
+
+    fnNotifySlackInstanceUpdate(
+      { ...objBaseInstance(), strServiceAbbr: 'FH/KR', strStatus: 'qa_deployed' },
+      true,
+    );
+    let objBody = JSON.parse(String((fnFetchMock.mock.calls[0][1] as RequestInit).body));
+    let objActions = objBody.blocks.find((b: { type: string }) => b.type === 'actions');
+    expect(objActions.elements[0].url).toBe('https://qa-db.example.com/my-dashboard?nInstanceId=42');
+
+    fnFetchMock.mockClear();
+    fnNotifySlackInstanceUpdate(
+      { ...objBaseInstance(), strServiceAbbr: 'FH/KR', strStatus: 'live_deployed' },
+      true,
+    );
+    objBody = JSON.parse(String((fnFetchMock.mock.calls[0][1] as RequestInit).body));
+    objActions = objBody.blocks.find((b: { type: string }) => b.type === 'actions');
+    expect(objActions.elements[0].url).toBe('https://db.example.com/my-dashboard?nInstanceId=42');
+  });
+
+  it('DQPM_PUBLIC_BASE_URL 없으면 대시보드 버튼(actions)을 넣지 않는다', async () => {
+    process.env.SLACK_NOTIFICATIONS_ENABLED = '1';
+    process.env.SLACK_WEBHOOK_URL_FH = 'https://hooks.slack.com/services/fh';
+    const { fnNotifySlackInstanceUpdate } = await import('../services/slackNotifier');
+    fnNotifySlackInstanceUpdate(
+      { ...objBaseInstance(), strServiceAbbr: 'FH/KR', strStatus: 'live_deployed' },
+      true,
+    );
+    const objBody = JSON.parse(String((fnFetchMock.mock.calls[0][1] as RequestInit).body));
+    const objActions = objBody.blocks.find((b: { type: string }) => b.type === 'actions');
+    expect(objActions).toBeUndefined();
   });
 
   it('SR QA 반영 완료는 sr 프로덕트 채널로 보낸다', async () => {

--- a/backend/src/services/slackNotifier.ts
+++ b/backend/src/services/slackNotifier.ts
@@ -74,9 +74,25 @@ const fnGetStatusLabel = (strStatus: TEventStatus, bPermanentlyRemoved?: boolean
   bPermanentlyRemoved ? '영구 삭제' : (OBJ_STATUS_LABEL[strStatus] ?? strStatus)
 );
 
-const fnGetPublicBaseUrl = (): string | null => {
-  const strBase = process.env.DQPM_PUBLIC_BASE_URL?.trim().replace(/\/$/, '');
+const fnTrimPublicBaseUrl = (strRaw?: string): string | null => {
+  const strBase = strRaw?.trim().replace(/\/$/, '');
   return strBase || null;
+};
+
+/** 공통 fallback — 템플릿 알림 등 환경 구분 없는 링크 */
+const fnGetPublicBaseUrl = (): string | null => (
+  fnTrimPublicBaseUrl(process.env.DQPM_PUBLIC_BASE_URL)
+);
+
+/** 인스턴스 상태별 대시보드 링크 — QA/LIVE EC2가 같은 webhook을 쓰거나 env가 하나만 있을 때도 올바른 호스트 */
+export const fnGetPublicBaseUrlForInstanceStatus = (strStatus: TEventStatus): string | null => {
+  const strDefault = fnTrimPublicBaseUrl(process.env.DQPM_PUBLIC_BASE_URL);
+  const strQa = fnTrimPublicBaseUrl(process.env.DQPM_PUBLIC_BASE_URL_QA);
+  const strLive = fnTrimPublicBaseUrl(process.env.DQPM_PUBLIC_BASE_URL_LIVE);
+
+  if (strStatus.startsWith('qa_')) return strQa || strDefault || null;
+  if (strStatus.startsWith('live_')) return strLive || strDefault || null;
+  return strDefault || strQa || strLive || null;
 };
 
 const fnParseNotifyStatuses = <T extends string>(
@@ -182,7 +198,7 @@ export const fnBuildSlackInstancePayload = (
     'nId' | 'strEventName' | 'strProductName' | 'strStatus' | 'bPermanentlyRemoved'
   >,
 ): Record<string, unknown> => {
-  const strBase = fnGetPublicBaseUrl();
+  const strBase = fnGetPublicBaseUrlForInstanceStatus(objInstance.strStatus);
   return fnBuildSlackBlockKitPayload({
     strTitle,
     strSubjectLabel: '이벤트',


### PR DESCRIPTION
…e statuses

- Introduced a new function to trim and manage public base URLs based on instance statuses (QA/LIVE).
- Updated the Slack notification payload to utilize the new instance-specific URL logic.
- Modified environment variable documentation to reflect the new QA and LIVE URL configurations.
- Added tests to ensure correct URL usage based on deployment status.